### PR TITLE
Remove unnecessary indexing bounds check when iterating.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,8 +268,8 @@ fn eliminate_holes(
     queue.sort_by(compare_x);
 
     // process holes from left to right
-    for i in 0..queue.len() {
-        eliminate_hole(ll, queue[i].idx, outer_node);
+    for node in queue {
+        eliminate_hole(ll, node.idx, outer_node);
         let nextidx = next!(ll, outer_node).idx;
         outer_node = filter_points(ll, outer_node, nextidx);
     }


### PR DESCRIPTION
On my machine, this speeds up `bench_simplified_us_border` by 35%

<img width="683" alt="Screen Shot 2020-12-07 at 12 52 09 PM" src="https://user-images.githubusercontent.com/416575/101386632-70dbe180-388b-11eb-8245-c22c5e2e2bd2.png">
