### PR TITLE
Allow earcut to work across both f64 and f32 types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "earcutr"
 version = "0.1.0"
 authors = ["don bright <hmbright@fastmail.com>"]
+edition = "2018"
+
+[dependencies]
+num-traits = "0.2"
 
 [dev-dependencies]
 serde = "1.0.80"
@@ -17,8 +21,3 @@ harness = false
 # Valgrind's Callgrind or Perf
 [profile.release] 
 debug = true
-
-# for profiling with CpuProfiler
-#[dependencies]
-#cpuprofiler = "0.0.3"
-

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -76,27 +76,15 @@ fn mkoutput(
         .truncate(true)
         .open(outfile)
         .unwrap();
-    try!(writeln!(&f, r###"testOutput["{}"]=[];"###, filename));
-    try!(writeln!(
-        &f,
-        r###"testOutput["{}"]["json"]={:?};"###,
-        filename, data
-    ));
-    try!(writeln!(
+    writeln!(&f, r###"testOutput["{}"]=[];"###, filename)?;
+    writeln!(&f, r###"testOutput["{}"]["json"]={:?};"###, filename, data)?;
+    writeln!(
         &f,
         r###"testOutput["{}"]["triangles"]={:?};"###,
         filename, tris
-    ));
-    try!(writeln!(
-        &f,
-        r###"testOutput["{}"]["pass"]={:?};"###,
-        filename, pass
-    ));
-    try!(writeln!(
-        &f,
-        r###"testOutput["{}"]["report"]={:?};"###,
-        filename, rpt
-    ));
+    )?;
+    writeln!(&f, r###"testOutput["{}"]["pass"]={:?};"###, filename, pass)?;
+    writeln!(&f, r###"testOutput["{}"]["report"]={:?};"###, filename, rpt)?;
     dlog!(4, "wrote results to {}", outfile);
     Ok(())
 }
@@ -130,8 +118,7 @@ fn area_test(filename: &str, expected_num_tris: usize, expected_deviation: f64) 
                         Some(parsed_data) => {
                             xdata = parsed_data;
                             let (data, holeidxs, dimensions) = earcutr::flatten(&xdata);
-                            triangles =
-                                earcutr::earcut(&data, &holeidxs, dimensions);
+                            triangles = earcutr::earcut(&data, &holeidxs, dimensions);
                             actual_num_tris = triangles.len() / 3;
                             actual_deviation =
                                 earcutr::deviation(&data, &holeidxs, dimensions, &triangles);
@@ -189,7 +176,7 @@ fn test_indices_3d() {
 
 #[test]
 fn test_empty() {
-    let indices = earcutr::earcut(&vec![], &vec![], 2);
+    let indices = earcutr::earcut::<f64>(&vec![], &vec![], 2);
     println!("{:?}", indices);
     assert!(indices.len() == 0);
 }


### PR DESCRIPTION
When working with WebGL through wasm it's useful to be able to keep data as f32